### PR TITLE
feat: support arm64 darwin

### DIFF
--- a/libcocoainput/darwin/libcocoainput/Makefile
+++ b/libcocoainput/darwin/libcocoainput/Makefile
@@ -1,5 +1,5 @@
 CC	= gcc
-CFLAGS	= -Wall -fobjc-arc -mmacosx-version-min=10.10
+CFLAGS	= -Wall -fobjc-arc -mmacosx-version-min=10.10 -arch x86_64 -arch arm64
 FFLAGS	= -framework Foundation -framework Cocoa
 OBJS	= cocoainput.o Logger.o DataManager.o MinecraftView.o
 LIBS	=


### PR DESCRIPTION
note: after apply this patch, you need to build it with macOS 11 SDK or newer.